### PR TITLE
Added support for serialization and deserialization

### DIFF
--- a/django_readonly_field/compiler.py
+++ b/django_readonly_field/compiler.py
@@ -49,6 +49,11 @@ class SQLUpdateCompiler(ReadOnlySQLCompilerMixin, BaseSQLUpdateCompiler):
 
 class SQLInsertCompiler(ReadOnlySQLCompilerMixin, BaseSQLInsertCompiler):
 
+    def _exclude_readonly_fields(self, fields, read_only_field_names):
+        for field in fields:
+            if field.name not in read_only_field_names:
+                yield field
+
     def remove_read_only_fields(self, read_only_field_names):
         """
         Remove the fields from the query which correspond to a
@@ -56,12 +61,9 @@ class SQLInsertCompiler(ReadOnlySQLCompilerMixin, BaseSQLInsertCompiler):
         """
         fields = self.query.fields
 
-        new_fields = (
-            field for field in fields
-            if field.name not in read_only_field_names
-        )
         try:
-            fields[:] = new_fields
+            fields[:] = self._exclude_readonly_fields(
+                fields, read_only_field_names)
         except AttributeError:
             # When deserializing, we might get an attribute error because this
             # list shoud be copied first :
@@ -70,4 +72,5 @@ class SQLInsertCompiler(ReadOnlySQLCompilerMixin, BaseSQLInsertCompiler):
             # should never be mutated. If you want to manipulate this list for
             # your own use, make a copy first."
 
-            self.query.fields = list(new_fields)
+            self.query.fields = list(self._exclude_readonly_fields(
+                fields, read_only_field_names))

--- a/django_readonly_field/compiler.py
+++ b/django_readonly_field/compiler.py
@@ -56,7 +56,18 @@ class SQLInsertCompiler(ReadOnlySQLCompilerMixin, BaseSQLInsertCompiler):
         """
         fields = self.query.fields
 
-        fields[:] = (
+        new_fields = (
             field for field in fields
             if field.name not in read_only_field_names
         )
+        try:
+            fields[:] = new_fields
+        except AttributeError:
+            # When deserializing, we might get an attribute error because this
+            # list shoud be copied first :
+
+            # "AttributeError: The return type of 'local_concrete_fields'
+            # should never be mutated. If you want to manipulate this list for
+            # your own use, make a copy first."
+
+            self.query.fields = list(new_fields)


### PR DESCRIPTION
This PR was made from the comments from @zebuline who warned me that (if I understood correctly) when deserializing data, the readonly field was present (when it should be absent).

There was also an ambiguity on the serialization behavior : read-only fields are fields and should be present in the serialization results.

I've added tests that check the (de/)serialization behaviour, and I did not reproduce such behaviour **but** I encountered a bug in the deserialization part, that this PR would solve.

The last question is about an option to allow skipping read-only fields when serializing the data. Thing is, I'm affraid this should more be the responsibility of a specific Serializer than an global option on the ReadOnlyMeta (which is the only interaction point so far). Would it be ok to examine a `SkipReadOnlyFieldsSerializerMixin` class that would be provided as part of this lib's API for the user to create their own Serializer ? (they would have to register it themselves though). I feel this coud be part of another PR.

@zebuline, I would appreciate your input and/or more details on this matter.

Of course, as soon as this gets merged, I'll do a release.
