### PR TITLE
Choosed [rR]eadonly as the only correct writing througout the lib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ In the model where you want some fields to be read-only:
         name = models.CharField(max_length=100)
         color = models.CharField(max_length=16)
 
-        class ReadOnlyMeta:
+        class ReadonlyMeta:
             readonly = ["color"]
 
 That's it. Now, Django won't try to write the ``color`` field on the database.

--- a/django_readonly_field/__init__.py
+++ b/django_readonly_field/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.1.1'
 
-default_app_config = "django_readonly_field.apps.ReadOnly"
+default_app_config = "django_readonly_field.apps.Readonly"

--- a/django_readonly_field/apps.py
+++ b/django_readonly_field/apps.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.apps import AppConfig
 
 
-class ReadOnly(AppConfig):
+class Readonly(AppConfig):
     name = 'django_readonly_field'
 
     def ready(self):

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -19,7 +19,7 @@ In the model where you want some fields to be read-only:
         name = models.CharField(max_length=100)
         color = models.CharField(max_length=16)
 
-        class ReadOnlyMeta:
+        class ReadonlyMeta:
             readonly = ["color"]
 
 That's it. Now, Django won't try to write the ``color`` field on the database.

--- a/tests/readonly_app/models.py
+++ b/tests/readonly_app/models.py
@@ -14,8 +14,8 @@ class Car(models.Model):
         return "{car.manufacturer} Car with {car.wheel_number} wheels".format(
             car=self)
 
-    class ReadOnlyMeta:
-        read_only = ["manufacturer"]
+    class ReadonlyMeta:
+        readonly = ["manufacturer"]
 
 
 @python_2_unicode_compatible
@@ -30,8 +30,8 @@ class Book(models.Model):
     def __str__(self):
         return "{book.name} (ref: {book.ref}, iban: {book.iban})"
 
-    class ReadOnlyMeta:
-        read_only = ["ref", "iban"]
+    class ReadonlyMeta:
+        readonly = ["ref", "iban"]
 
 
 @python_2_unicode_compatible
@@ -48,5 +48,5 @@ class Bus(models.Model):
         return "{car.manufacturer} Bus with {car.wheel_number} wheels".format(
             car=self)
 
-    class ReadOnlyMeta:
-        read_only = ["wheel_number"]
+    class ReadonlyMeta:
+        readonly = ["wheel_number"]

--- a/tests/readonly_app/tests.py
+++ b/tests/readonly_app/tests.py
@@ -12,7 +12,7 @@ from .models import Bus
 from .models import Book
 
 
-class ReadOnlyFieldTest(TestCase):
+class ReadonlyFieldTest(TestCase):
 
     # Note : the default for fields is in the file 0002_sql_default.py
     # Default values are :
@@ -35,12 +35,12 @@ class ReadOnlyFieldTest(TestCase):
     def assertSQLQueries(self, model=None, check_other_fields=True):
         """
         Asserts that the SQL from the queries don't mention
-        the read_only field. SELECTS are authorized, though.
+        the readonly field. SELECTS are authorized, though.
         model allow you to specify the model for which readonly
         fields will be checked
         """
         model = model or Car
-        readonly_fields = model.ReadOnlyMeta.read_only
+        readonly_fields = model.ReadonlyMeta.readonly
         with CaptureQueriesContext(connection=connection) as capture:
             yield capture
 


### PR DESCRIPTION
Sorry for the stuff breaking for people already using the lib...
