### PR TITLE
Publish workflow should just run on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,7 @@ on:
   push:
     tags:
       - '*'
-  release:
-    types:
-      - published
-
+      
 jobs:
   deploy:
     name: Publish package to PyPI


### PR DESCRIPTION
Fixes the publish workflow wich runs twice, one of which will fail.