### PR TITLE
Remove outdated version info

### DIFF
--- a/django_readonly_field/__init__.py
+++ b/django_readonly_field/__init__.py
@@ -1,7 +1,4 @@
 import django
 
-__version__ = "1.0.6dev0"
-
-
 if django.VERSION[:2] < (3, 2):
     default_app_config = "django_readonly_field.apps.Readonly"


### PR DESCRIPTION
The __version__ is not updated.

Note sure exactly why, given [Poetry-dynamic-versionning](https://pypi.org/project/poetry-dynamic-versioning/) says it should update it, but hey. At least let's not give a false info

